### PR TITLE
DM-26629: Update test code to new form of butler.get for calibrations.

### DIFF
--- a/tests/test_bias.py
+++ b/tests/test_bias.py
@@ -27,7 +27,6 @@ import lsst.daf.butler as dafButler
 import lsst.ip.isr as ipIsr
 import lsst.meas.algorithms as measAlg
 import lsst.utils.tests
-
 from lsst.pipe.tasks.repair import RepairTask
 
 
@@ -77,16 +76,12 @@ class BiasTestCases(lsst.utils.tests.TestCase):
         config.doUseAtmosphereTransmission = False
 
         isrTask = ipIsr.IsrTask(config=config)
+        rawDataId = {'detector': 0, 'exposure': 2020012800007, 'instrument': 'LATISS'}
         # TODO: DM-26396
         # This is not an independent frame.
-        cls.raw = butler.get('raw', dataId={'detector': 0, 'exposure': 2020012800007,
-                                            'instrument': 'LATISS'})
-        cls.bias = butler.get('bias', dataId={'detector': 0,
-                                              'instrument': 'LATISS',
-                                              'calibration_label': 'bias/ci_cpp_bias'})
-        cls.camera = butler.get('camera', dataId={'detector': 0, 'exposure': 2020012800007,
-                                                  'instrument': 'LATISS',
-                                                  'calibration_label': 'unbounded'})
+        cls.raw = butler.get('raw', dataId=rawDataId)
+        cls.bias = butler.get('bias', rawDataId)
+        cls.camera = butler.get('camera', rawDataId)
 
         results = isrTask.run(cls.raw, camera=cls.camera,
                               bias=cls.bias)

--- a/tests/test_dark.py
+++ b/tests/test_dark.py
@@ -77,19 +77,13 @@ class DarkTestCases(lsst.utils.tests.TestCase):
         config.doUseAtmosphereTransmission = False
 
         isrTask = ipIsr.IsrTask(config=config)
+        rawDataId = {'detector': 0, 'exposure': 2020012800007, 'instrument': 'LATISS'}
         # TODO: DM-26396
         # This is not an independent frame.
-        cls.raw = butler.get('raw', dataId={'detector': 0, 'exposure': 2020012800014,
-                                            'instrument': 'LATISS'})
-        cls.bias = butler.get('bias', dataId={'detector': 0,
-                                              'instrument': 'LATISS',
-                                              'calibration_label': 'bias/ci_cpp_bias'})
-        cls.dark = butler.get('dark', dataId={'detector': 0,
-                                              'instrument': 'LATISS',
-                                              'calibration_label': 'dark/ci_cpp_dark'})
-        cls.camera = butler.get('camera', dataId={'detector': 0, 'exposure': 2020012800014,
-                                                  'instrument': 'LATISS',
-                                                  'calibration_label': 'unbounded'})
+        cls.raw = butler.get('raw', rawDataId)
+        cls.bias = butler.get('bias', rawDataId)
+        cls.dark = butler.get('dark', rawDataId)
+        cls.camera = butler.get('camera', rawDataId)
 
         results = isrTask.run(cls.raw, camera=cls.camera,
                               bias=cls.bias, dark=cls.dark)

--- a/tests/test_dark.py
+++ b/tests/test_dark.py
@@ -77,7 +77,7 @@ class DarkTestCases(lsst.utils.tests.TestCase):
         config.doUseAtmosphereTransmission = False
 
         isrTask = ipIsr.IsrTask(config=config)
-        rawDataId = {'detector': 0, 'exposure': 2020012800007, 'instrument': 'LATISS'}
+        rawDataId = {'detector': 0, 'exposure': 2020012800014, 'instrument': 'LATISS'}
         # TODO: DM-26396
         # This is not an independent frame.
         cls.raw = butler.get('raw', rawDataId)

--- a/tests/test_flat.py
+++ b/tests/test_flat.py
@@ -73,23 +73,14 @@ class FlatTestCases(lsst.utils.tests.TestCase):
         config.doUseAtmosphereTransmission = False
 
         isrTask = ipIsr.IsrTask(config=config)
+        rawDataId = {'detector': 0, 'exposure': 2020012800007, 'instrument': 'LATISS'}
         # TODO: DM-26396
         # This is not an independent frame.
-        cls.raw = butler.get('raw', dataId={'detector': 0, 'exposure': 2020012800028,
-                                            'instrument': 'LATISS'})
-        cls.bias = butler.get('bias', dataId={'detector': 0,
-                                              'instrument': 'LATISS',
-                                              'calibration_label': 'bias/ci_cpp_bias'})
-        cls.dark = butler.get('dark', dataId={'detector': 0,
-                                              'instrument': 'LATISS',
-                                              'calibration_label': 'dark/ci_cpp_dark'})
-        cls.flat = butler.get('flat', dataId={'detector': 0,
-                                              'instrument': 'LATISS',
-                                              'physical_filter': 'KPNO_406_828nm~EMPTY',
-                                              'calibration_label': 'flat/ci_cpp_flat'})
-        cls.camera = butler.get('camera', dataId={'detector': 0, 'exposure': 2020012800028,
-                                                  'instrument': 'LATISS',
-                                                  'calibration_label': 'unbounded'})
+        cls.raw = butler.get('raw', rawDataId)
+        cls.bias = butler.get('bias', rawDataId)
+        cls.dark = butler.get('dark', rawDataId)
+        cls.flat = butler.get('flat', rawDataId)
+        cls.camera = butler.get('camera', rawDataId)
 
         results = isrTask.run(cls.raw, camera=cls.camera,
                               bias=cls.bias, dark=cls.dark, flat=cls.flat)

--- a/tests/test_flat.py
+++ b/tests/test_flat.py
@@ -73,7 +73,7 @@ class FlatTestCases(lsst.utils.tests.TestCase):
         config.doUseAtmosphereTransmission = False
 
         isrTask = ipIsr.IsrTask(config=config)
-        rawDataId = {'detector': 0, 'exposure': 2020012800007, 'instrument': 'LATISS'}
+        rawDataId = {'detector': 0, 'exposure': 2020012800028, 'instrument': 'LATISS'}
         # TODO: DM-26396
         # This is not an independent frame.
         cls.raw = butler.get('raw', rawDataId)


### PR DESCRIPTION
Butler.get can now be used to obtain a calibration product given a raw data ID.