### PR TITLE
DM-28184: gen3 crosstalk generation does not set DET_NAME correctly.

### DIFF
--- a/pipelines/runIsr.yaml
+++ b/pipelines/runIsr.yaml
@@ -5,4 +5,4 @@ tasks:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
       doLinearize: False
-      doCrosstalk: False
+      doCrosstalk: True


### PR DESCRIPTION
Use crosstalk in the science test, as it is now being generated.