### PR TITLE
DM-36000: Remove command-line task mention

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,11 +3,10 @@
 This configuration only affects single-package Sphinx documentation builds.
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.ci.cpp.gen3
+from documenteer.conf.pipelinespkg import *  # noqa: F403, import *
 
-
-_g = globals()
-_g.update(build_package_configs(
-    project_name='ci_cpp_gen3',
-    version=lsst.ci.cpp.gen3.version.__version__))
+project = "ci_cpp_gen3"
+html_theme_options["logotext"] = project     # noqa: F405, unknown name
+html_title = project
+html_short_title = project
+doxylink = {}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,14 +55,6 @@ Pipeline tasks
 .. lsst-pipelinetasks::
    :root: lsst.ci.cpp.gen3
 
-.. _lsst.ci.cpp.gen3-command-line-tasks:
-
-Command-line tasks
-------------------
-
-.. lsst-cmdlinetasks::
-   :root: lsst.ci.cpp.gen3
-
 .. _lsst.ci.cpp.gen3-tasks:
 
 Tasks


### PR DESCRIPTION
@czwa I can't seem to get any docs to build in this package and the sphinx docs themselves look like they are lot of unused template. Removing the command-line task mention seems like a good idea regardless.