### PR TITLE
DM-38765: Exclude gen3.sqlite3 from MemoryTestCase.

### DIFF
--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -136,7 +136,7 @@ class OutputTestCases(lsst.utils.tests.TestCase):
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
-    pass
+    ignore_regexps = [r"/?gen3.sqlite3$"]
 
 
 def setup_module(module):


### PR DESCRIPTION
This makes the code compatible with SQLAlchemy 2.