### PR TITLE
DM-42024: Change threshold on CTI to be less sensitive to input test data.

### DIFF
--- a/pipelines/cpDeferredCharge.yaml
+++ b/pipelines/cpDeferredCharge.yaml
@@ -1,0 +1,9 @@
+description: cp_pipe CTI calibration construction -- for ci_cpp only!
+instrument: lsst.obs.lsst.Latiss
+imports:
+  - location: $CP_PIPE_DIR/pipelines/_ingredients/cpDeferredCharge.yaml
+tasks:
+    solveCti:
+    class: lsst.cp.pipe.CpCtiSolveTask
+    config:
+      maxSignalForCti: 20000

--- a/pipelines/cpDeferredCharge.yaml
+++ b/pipelines/cpDeferredCharge.yaml
@@ -3,7 +3,7 @@ instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $CP_PIPE_DIR/pipelines/_ingredients/cpDeferredCharge.yaml
 tasks:
-    solveCti:
+  solveCti:
     class: lsst.cp.pipe.CpCtiSolveTask
     config:
       maxSignalForCti: 20000


### PR DESCRIPTION
This avoids a possible inconsistency between linux/macos