### PR TITLE
Fix issue with partial rebuilds in SCons

### DIFF
--- a/DATA/SConscript
+++ b/DATA/SConscript
@@ -4,7 +4,7 @@ import yaml
 import lsst.sconsUtils as utils
 from lsst.sconsUtils.utils import libraryLoaderEnvironment
 
-from SCons.Script import SConscript, GetOption
+from SCons.Script import SConscript, GetOption, File, Dir
 
 
 env = utils.env.Clone(ENV=os.environ)
@@ -183,9 +183,9 @@ def getVerifyCmd(stage, expList, pipelineFile):
 
 # Begin ci_cpp build commands.
 # Create the butler, register the instrument, and add calibs.
-butler = env.Command([os.path.join(REPO_ROOT, "gen3.sqlite3"),
-                      os.path.join(REPO_ROOT, "butler.yaml"),
-                      os.path.join(REPO_ROOT, "LATISS", "calib")], None,
+butler = env.Command([File(os.path.join(REPO_ROOT, "gen3.sqlite3")),
+                      File(os.path.join(REPO_ROOT, "butler.yaml")),
+                      Dir(os.path.join(REPO_ROOT, "LATISS", "calib"))], None,
                      [getExecutableCmd("daf_butler", "butler",
                                        "create", REPO_ROOT),
                       getExecutableCmd("daf_butler", "butler",


### PR DESCRIPTION
When SCons runs the "butler" target, sometimes it erroneously replaced the gen3 butler SQLite file with an empty directory.

The exact reasons for this are unclear, but it appears that explicitly tagging the sqlite3 and yaml files as File, and the directories as Dir within SConscript causes the SCons dblite file to be generated properly and to allow for SCons targets to rebuild. 

Should fix DM-44406