### PR TITLE
DM-46297: override guards against unlabeled curated calibration collections

### DIFF
--- a/DATA/SConscript
+++ b/DATA/SConscript
@@ -190,7 +190,7 @@ butler = env.Command([File(os.path.join(REPO_ROOT, "gen3.sqlite3")),
                                        "register-instrument", REPO_ROOT, CAMERA),
                       getExecutableCmd("daf_butler", "butler",
                                        "write-curated-calibrations", REPO_ROOT,
-                                       CAMERA),
+                                       CAMERA, "--collection", "LATISS/calib"),
                   ])
 env.Alias("butler", butler)
 


### PR DESCRIPTION
This lets us keep using LATISS/calib as the name of the calibration collection and hence avoid a lot of churn.